### PR TITLE
Add ARM x64 support by OpenJDK offical image usage.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,18 @@
-ARG PYTHON_VERSION=3.9.4
-FROM python:$PYTHON_VERSION
+ARG OPENJDK_VERSION=8u312-b07-jdk
+FROM eclipse-temurin:$OPENJDK_VERSION
+
+RUN apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends wget \
+    && rm -rf /var/lib/apt/lists/*
 
 USER root
 WORKDIR /opt
-RUN wget -c --header "Cookie: oraclelicense=accept-securebackup-cookie" http://download.oracle.com/otn-pub/java/jdk/8u131-b11/d54c1d3a095b4ff2b6607d096fa80163/jdk-8u131-linux-x64.tar.gz && \
-    wget https://downloads.lightbend.com/scala/2.13.5/scala-2.13.5.tgz && \
+RUN wget https://downloads.lightbend.com/scala/2.13.5/scala-2.13.5.tgz && \
     wget https://archive.apache.org/dist/spark/spark-3.1.1/spark-3.1.1-bin-hadoop3.2.tgz && \
     wget https://github.com/sbt/sbt/releases/download/v1.3.0/sbt-1.3.0.tgz
-RUN tar xzf jdk-8u131-linux-x64.tar.gz && \
-    tar xvf scala-2.13.5.tgz && \
+RUN tar xvf scala-2.13.5.tgz && \
     tar xvf spark-3.1.1-bin-hadoop3.2.tgz && \
     tar xvf sbt-1.3.0.tgz
-ENV PATH="/opt/jdk1.8.0_131/bin:/opt/scala-2.13.5/bin:/opt/spark-3.1.1-bin-hadoop3.2/bin:/opt/sbt/bin:/opt/sbt/bin$PATH"
+ENV PATH="/opt/scala-2.13.5/bin:/opt/spark-3.1.1-bin-hadoop3.2/bin:/opt/sbt/bin:${PATH}"
 
 WORKDIR /app
-
-


### PR DESCRIPTION
Hi,

Some of the new MacBooks use the ARM architecture based chipset. But our Dockerfile was always statically using the amd64 based Oracle JDK binary. With this change, it should start supporting ARM-based machines as well.

OpenJDK project moved to Eclipse foundation and rebranded to [Temurin project](https://adoptium.net/). Please always stick to official images.

Best wishes,
Burak Ince