### PR TITLE
Upgrade to Spark 3.2.x

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,14 +4,14 @@ FROM python:$PYTHON_VERSION
 USER root
 WORKDIR /opt
 RUN wget -c --header "Cookie: oraclelicense=accept-securebackup-cookie" http://download.oracle.com/otn-pub/java/jdk/8u131-b11/d54c1d3a095b4ff2b6607d096fa80163/jdk-8u131-linux-x64.tar.gz && \
-    wget https://downloads.lightbend.com/scala/2.13.5/scala-2.13.5.tgz && \
-    wget https://archive.apache.org/dist/spark/spark-3.1.1/spark-3.1.1-bin-hadoop3.2.tgz && \
+    wget https://downloads.lightbend.com/scala/2.12.15/scala-2.12.15.tgz && \
+    wget https://archive.apache.org/dist/spark/spark-3.2.1/spark-3.2.1-bin-hadoop3.2.tgz && \
     wget https://github.com/sbt/sbt/releases/download/v1.3.0/sbt-1.3.0.tgz
 RUN tar xzf jdk-8u131-linux-x64.tar.gz && \
-    tar xvf scala-2.13.5.tgz && \
-    tar xvf spark-3.1.1-bin-hadoop3.2.tgz && \
+    tar xvf scala-2.12.15.tgz && \
+    tar xvf spark-3.2.1-bin-hadoop3.2.tgz && \
     tar xvf sbt-1.3.0.tgz
-ENV PATH="/opt/jdk1.8.0_131/bin:/opt/scala-2.13.5/bin:/opt/spark-3.1.1-bin-hadoop3.2/bin:/opt/sbt/bin:/opt/sbt/bin$PATH"
+ENV PATH="/opt/jdk1.8.0_131/bin:/opt/scala-2.12.15/bin:/opt/spark-3.2.1-bin-hadoop3.2/bin:/opt/sbt/bin:/opt/sbt/bin$PATH"
 
 WORKDIR /app
 

--- a/README-LOCAL.md
+++ b/README-LOCAL.md
@@ -7,7 +7,7 @@ These jobs are using _Spark_ to process larger volumes of data and are supposed 
 Please make sure you have the following installed
 * Java 8
 * Scala 2.12
-* Sbt 1.1.x
+* Sbt 1.3.x
 * Apache Spark 2.4 with ability to run spark-submit
 
 ## Setup Process

--- a/README-LOCAL.md
+++ b/README-LOCAL.md
@@ -8,7 +8,7 @@ Please make sure you have the following installed
 * Java 8
 * Scala 2.12
 * Sbt 1.3.x
-* Apache Spark 2.4 with ability to run spark-submit
+* Apache Spark 3.2 with ability to run spark-submit
 
 ## Setup Process
 * Clone the repo

--- a/build.sbt
+++ b/build.sbt
@@ -1,14 +1,14 @@
 
-scalaVersion := "2.12.4"
+scalaVersion := "2.12.15"
 
-val sparkVersion = "2.4.0"
+val sparkVersion = "3.2.1"
 
 
 lazy val root = (project in file(".")).
   settings(
     inThisBuild(List(
       organization := "com.thoughtworks.cd.de",
-      scalaVersion := "2.12.4",
+      scalaVersion := "2.12.15",
       version := "0.1.0-SNAPSHOT"
     )),
 


### PR DESCRIPTION
# PR Details

## Contains
Upgrade to Spark 3.2.1
Upgrade to Scala version to be the latest patch version of 2.12.x (2.12.4 -> 2.12.15)
Fix to a typo in README referencing incorrect version of sbt

## Test with Colima

### Environment
```
$ sw_vers
ProductName:	macOS
ProductVersion:	12.2.1
BuildVersion:	21D62
```
```
$ ./batect --docker-host=unix://$HOME/.colima/docker.sock --version
Batect version:    0.74.0
Built:             2021-09-05 11:50:34 +0000
Built from commit: 882f6c4ba18ab5385373185e0c9e75f928f980ea (commit date: 2021-09-05 20:20:09 +1000)
JVM version:       Eclipse Adoptium OpenJDK 64-Bit Server VM 11.0.13
OS version:        Mac OS X 12.2.1 x86_64
Docker version:    20.10.11 (API version: 1.41, minimum supported API version: 1.12, commit: 847da184ad5048b27f5bdf9d53d070f731b43180, operating system: 'linux', experimental: false)
Git version:       2.34.0
...
...
```
```
(global-anaconda3-2020.07) srikars-mbp-2:dataengineer-transformations-scala sayilava$ colima version
colima version 0.3.4
git commit: 5a4a70481ca8d1e794677f22524e3c1b79a9b4ae

runtime: docker
arch: x86_64
client: v20.10.13
server: v20.10.11
```

### Commands run
```
./batect --docker-host=unix://$HOME/.colima/docker.sock unit-test
./batect --docker-host=unix://$HOME/.colima/docker.sock style-checks
INPUT_FILE_PATH="src/test/resources/data/words.txt" JOB=thoughtworks.wordcount.WordCount ./batect --docker-host=unix://$HOME/.colima/docker.sock run-job
INPUT_FILE_PATH="src/test/resources/data/citibike.csv" JOB=thoughtworks.ingest.DailyDriver ./batect --docker-host=unix://$HOME/.colima/docker.sock run-job
INPUT_FILE_PATH=${output_parquest_ingest} JOB=thoughtworks.citibike.CitibikeTransformer ./batect --docker-host=unix://$HOME/.colima/docker.sock run-job
```

### Status
All commands ran successfully

## Remaining

